### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build generate push
+permissions:
+  contents: read
 on: [push]
 jobs:
   list-modules:


### PR DESCRIPTION
Potential fix for [https://github.com/talbs1986/simplego/security/code-scanning/5](https://github.com/talbs1986/simplego/security/code-scanning/5)

In general, to fix this class of issue you explicitly define a `permissions` block in the workflow or per job, limiting the `GITHUB_TOKEN` to the minimal scopes required (typically `contents: read` for basic CI that only needs to fetch code). For this particular workflow, the jobs only check out code, compute changed directories, and run build/lint/test locally; they do not appear to need any write permissions on the repository or other elevated scopes.

The best fix without changing existing behavior is to add a workflow‑level `permissions` block (so it applies to both `list-modules` and `build-modules`) giving only `contents: read`. This is placed at the top level alongside `name` and `on`. No other scopes appear necessary: `actions/checkout` and `tj-actions/changed-files` work with `contents: read`, and the shell commands only operate on the checked‑out workspace. Concretely, in `.github/workflows/build.yml`, after line 1 (the `name:` line) and before the `on:` line, insert:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
